### PR TITLE
Add support for PIE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "m6w6/ext-apfd",
+    "type": "php-ext",
+    "license": "BSD-2-Clause",
+    "description": "Always Populate Form Data",
+    "require": {
+        "php": ">= 5.3.0"
+    },
+    "php-ext": {
+        "extension-name": "apfd"
+    }
+}


### PR DESCRIPTION
Adds support for [PIE](https://github.com/php/pie).

Once merged, a maintainer would need to add this repo's URL to https://packagist.org/packages/submit :)

More info/documentation can be read on: https://github.com/php/pie/blob/main/docs/extension-maintainers.md